### PR TITLE
fix: use self hosted runner for sync test

### DIFF
--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -127,7 +127,7 @@ jobs:
     test:
         timeout-minutes: 1440 # 24 hours
         needs: prepare
-        runs-on: ubuntu-latest
+        runs-on: [self-hosted-ghr-custom, size-xl-x64]
         concurrency:
             group: >-
                 ${{ github.head_ref || inputs.concurrency_group }}-sync


### PR DESCRIPTION
fixing runs like these: https://github.com/ethpandaops/hive-tests/actions/runs/18516867422/job/52769018189#step:5:6564