### PR TITLE
chore(hive): add missing clients to `client_repos` default in BAL workflow

### DIFF
--- a/.github/workflows/hive-devnet-3.yaml
+++ b/.github/workflows/hive-devnet-3.yaml
@@ -42,7 +42,10 @@ on:
             "geth": "ethereum/go-ethereum@master",
             "besu": "besu-eth/besu@main",
             "reth": "paradigmxyz/reth@main",
-            "nethermind": "NethermindEth/nethermind@master"
+            "nethermind": "NethermindEth/nethermind@master",
+            "erigon": "erigontech/erigon@main",
+            "nimbusel": "status-im/nimbus-eth1@master",
+            "ethrex": "lambdaclass/ethrex@main"
           }
         description: 'JSON object containing client versions in format {"client": "repo@tag", ...}'
       client_images:


### PR DESCRIPTION
The client_repos default for workflow_dispatch only had 4 clients (geth, besu, reth, nethermind) but the matrix tests 7 clients. When dispatched with client_source=git, the client-config action fails with a jq parse error for erigon, nimbus-el, and ethrex.
