### PR TITLE
chore(hive): add fork-based `sim.limit` to full BAL workflow

### DIFF
--- a/.github/workflows/hive-devnet-3.yaml
+++ b/.github/workflows/hive-devnet-3.yaml
@@ -82,12 +82,16 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
+    --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
   EELS_RLP_FLAGS: >-
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
+    --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/execute simulator
   EELS_EXECUTE_FLAGS: >-


### PR DESCRIPTION
The full BAL workflow had no `--sim.limit`, causing it to run all ~84k fixtures across every fork (Frontier through Amsterdam). This exhausted the 30GB self-hosted runner memory with `--sim.parallelism=6`, killing the hive process before completion and preventing S3 result uploads.