### PR TITLE
chore(hive): set HIVE_AMSTERDAM_TIMESTAMP for snobal-devnet-5

### DIFF
--- a/.github/workflows/hive-snobal-devnet-5-quick.yaml
+++ b/.github/workflows/hive-snobal-devnet-5-quick.yaml
@@ -120,7 +120,7 @@ jobs:
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
-      HIVE_AMSTERDAM_TIMESTAMP: "1759250952"
+      HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
       # Hardcoded EELS build args pinned to snobal-devnet-5@v8037.0.0
       EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-5@v8037.0.0/fixtures_snobal-devnet-5.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/snobal/5"

--- a/.github/workflows/hive-snobal-devnet-5.yaml
+++ b/.github/workflows/hive-snobal-devnet-5.yaml
@@ -156,7 +156,7 @@ jobs:
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
-      HIVE_AMSTERDAM_TIMESTAMP: "1759250952"
+      HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
       # Hardcoded EELS build args pinned to snobal-devnet-5@v8037.0.0
       EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-5@v8037.0.0/fixtures_snobal-devnet-5.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/snobal/5"


### PR DESCRIPTION
## Summary
- Updates `HIVE_AMSTERDAM_TIMESTAMP` in both `hive-snobal-devnet-5-quick.yaml` and `hive-snobal-devnet-5.yaml` from the inherited `1759250952` (from the bal-devnet-4 workflow) to `1777456800` — the actual devnet-5 genesis timestamp from `bal-devnets/ansible/inventories/devnet-5/group_vars/all/all.yaml` (2026-04-29 10:00:00 UTC).

Follow-up to #47.

## Test plan
- [ ] Trigger one scheduled or dispatched run after merge and confirm clients pick up the correct Amsterdam fork timestamp in their genesis chainspec.