### PR TITLE
chore(hive): point BAL workflows at bal-devnet-7

### DIFF
--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -1,4 +1,4 @@
-name: Hive - SNOBAL Devnet 6 Quick
+name: Hive - BAL Devnet 7 Quick
 on:
   schedule:
     - cron: "45 12 * * *"
@@ -10,7 +10,7 @@ on:
         description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex
       simulator:
         type: string
-        # TODO: add back "ethereum/eels/consume-rlp" when clients have snobal-devnet-6 branch
+        # TODO: add back "ethereum/eels/consume-rlp" when clients have bal-devnet-7 branch
         default: >-
           "ethereum/eels/consume-engine"
         description: >-
@@ -34,7 +34,7 @@ on:
         type: string
         description: >-
           If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
-        default: "bal-devnet-6"
+        default: "bal-devnet-7"
       client_repos:
         type: string
         default: |
@@ -109,7 +109,7 @@ jobs:
         with:
           client_repos: ${{ inputs.client_repos }}
           client_images: ${{ inputs.client_images }}
-          common_client_tag: ${{ inputs.common_client_tag || 'bal-devnet-6' }}
+          common_client_tag: ${{ inputs.common_client_tag || 'bal-devnet-7' }}
           client_source: ${{ inputs.client_source || 'git' }}
           hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
           goproxy: ${{ env.GOPROXY }}
@@ -121,9 +121,9 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to snobal-devnet-6@v1.1.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-6@v1.1.0/fixtures_snobal-devnet-6.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/snobal/6"
+      # Hardcoded EELS build args pinned to bal@v7.0.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.0.0/fixtures_bal.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{
         matrix.simulator == 'ethereum/rpc-compat' && 'ubuntu-latest' ||
@@ -146,7 +146,7 @@ jobs:
             "reth",
             "ethrex"
           '))}}
-        # TODO: add back "ethereum/eels/consume-rlp" when clients have snobal-devnet-6 branch
+        # TODO: add back "ethereum/eels/consume-rlp" when clients have bal-devnet-7 branch
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '
             "ethereum/eels/consume-engine"

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -1,4 +1,4 @@
-name: Hive - SNOBAL Devnet 6
+name: Hive - BAL Devnet 7
 on:
   schedule:
     - cron: "45 13 * * *"
@@ -34,7 +34,7 @@ on:
         type: string
         description: >-
           If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
-        default: "bal-devnet-6"
+        default: "bal-devnet-7"
       client_repos:
         type: string
         default: |
@@ -133,7 +133,7 @@ jobs:
         name: "Client config: schedule"
         id: client_config_schedule
         with:
-          common_client_tag: "bal-devnet-6"
+          common_client_tag: "bal-devnet-7"
           client_source: "git"
           hive_version: "ethereum/hive@master"
           goproxy: ${{ env.GOPROXY }}
@@ -157,9 +157,9 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to snobal-devnet-6@v1.1.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/snobal-devnet-6@v1.1.0/fixtures_snobal-devnet-6.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/snobal/6"
+      # Hardcoded EELS build args pinned to bal@v7.0.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.0.0/fixtures_bal.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{
         matrix.simulator == 'ethereum/rpc-compat' && 'ubuntu-latest' ||


### PR DESCRIPTION
## Summary

- Rename `hive-devnet-6{,-quick}.yaml` → `hive-devnet-7{,-quick}.yaml` and rename the workflows (`Hive - SNOBAL Devnet 6` → `Hive - BAL Devnet 7`)
- Bump `common_client_tag` default from `bal-devnet-6` → `bal-devnet-7`
- Repin EELS fixtures/branch to [`bal@v7.0.0`](https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v7.0.0) (`fixtures_bal.tar.gz`) and `devnets/bal/7`
- Refresh `snobal-devnet-6 branch` TODO comments to `bal-devnet-7 branch`

Spec: https://gist.github.com/qu0b/f3f905cadee4464a1a941838a5a5fadb (last `bal-`-prefixed devnet).
