### PR TITLE
chore(hive): bump BAL devnet-7 fixtures to bal@v7.1.0

### DIFF
--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -121,8 +121,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.0.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.0.0/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.1.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -157,8 +157,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.0.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.0.0/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.1.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
## Summary

- Repin EELS fixtures on `Hive - BAL Devnet 7` and `Hive - BAL Devnet 7 Quick` from [`bal@v7.0.0`](https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v7.0.0) → [`bal@v7.1.0`](https://github.com/ethereum/execution-spec-tests/releases/tag/bal@v7.1.0)
- EELS branch (`devnets/bal/7`) unchanged

Picks up the follow-up [`tests-bal@v7.1.0`](https://github.com/ethereum/execution-specs/releases/tag/tests-bal@v7.1.0) release:
- All SELFDESTRUCT state-gas refunds removed from EIP-8037
- EIP-7702 auth refund refill fix on non-empty code-hash delegation pointer (missed in v7.0.0)
- 300+ extra tests fixed from the ported static skip list (specs#2839)
- Additional BAL coverage (specs#2834)

## Test plan

- [ ] Trigger `Hive - BAL Devnet 7 Quick` via `workflow_dispatch` and confirm fixtures resolve from `bal@v7.1.0`
- [ ] Trigger `Hive - BAL Devnet 7` via `workflow_dispatch` and confirm a single client/sim matrix entry runs end-to-end