### PR TITLE
Migrate BAL devnet-7 fixture URLs to ethereum/execution-specs

### DIFF
--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -122,7 +122,7 @@ jobs:
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
       # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.1/fixtures_bal.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.1.1/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -121,8 +121,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.1.1/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.2.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.2.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -157,8 +157,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.1.1/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.2.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.2.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -158,7 +158,7 @@ jobs:
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
       # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.1/fixtures_bal.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.1.1/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
## Summary

- Point BAL devnet-7 workflows at `ethereum/execution-specs` (the canonical repo as of 2025-11-01) instead of the legacy `ethereum/execution-spec-tests` mirror.
- URL change only — asset (`fixtures_bal.tar.gz`, 609,842,087 bytes) is byte-identical between the two repos.

## Why

[The `execution-spec-tests` README](https://github.com/ethereum/execution-spec-tests) now states:

> ⚠️ NOTICE: All code from this repository has been migrated to ethereum/execution-specs
> this repository is no longer accepting pull requests as of 2025-11-01

The README does claim _"Client Teams: No changes. Test fixture releases will continue to be published in this repository"_, but the empirical signal points the other way:

| Signal | EEST (`execution-spec-tests`) | execution-specs |
|---|---|---|
| `tests-bal@v7.1.1` publish time | 2026-05-18T09:03:13Z | 2026-05-13T15:34:11Z (5 days earlier) |
| Downloads | 8 | 10,153 |
| All recent releases `created_at` | bulk-imported `2025-11-20T02:40:12Z` | live timestamps |
| `prerelease` flag | every BAL/zkevm/snobal/benchmark release | same |
| "Latest" badge | stuck on `v5.4.0` (2025-12-06) | live |

The EEST releases page is effectively a programmatic mirror, with a single bulk-import `created_at` for all BAL releases and the "Latest" pointer pegged to last year's `v5.4.0`. The active source is `execution-specs`.

## Diff

```diff
- https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.1/fixtures_bal.tar.gz
+ https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.1.1/fixtures_bal.tar.gz
```

Two files: `.github/workflows/hive-devnet-7.yaml`, `.github/workflows/hive-devnet-7-quick.yaml`.

## Not migrated

`.github/workflows/generic.yaml:93` still references `execution-spec-tests/.../v5.3.0/fixtures_stable.tar.gz`. **Intentional** — `execution-specs`'s `vX.Y.Z` tags are Python package releases (`ethereum_execution-*.whl` / `.tar.gz`), not fixture tarballs. There is no `fixtures_stable.tar.gz` equivalent on `execution-specs` yet. Will revisit alongside the existing `# Bump to develop soon (TM)` TODO on that line.

## Test plan

- [ ] Asset URL resolves (HTTP 302 → ~610 MB tarball): verified locally with `curl -sL`
- [ ] BAL devnet-7 hive-devnet-7-quick workflow run succeeds against the new URL
- [ ] BAL devnet-7 hive-devnet-7 full workflow run succeeds against the new URL