### PR TITLE
chore(hive): bump BAL devnet-7 fixtures to bal@v7.2.0

### DIFF
--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -121,8 +121,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.1/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.2.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.2.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -157,8 +157,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.1.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.1.1/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.2.0
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-spec-tests/releases/download/bal@v7.2.0/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
## Summary
- Bump EELS fixture URL in both `hive-devnet-7-quick.yaml` and `hive-devnet-7.yaml` from `bal@v7.1.1` to `bal@v7.2.0`
- Picks up the latest release: https://github.com/ethereum/execution-specs/releases/tag/tests-bal%40v7.2.0

## Test plan
- [ ] Trigger the BAL Devnet 7 Quick workflow and confirm fixtures download succeeds
- [ ] Trigger the BAL Devnet 7 (full) workflow and confirm fixtures download succeeds