### PR TITLE
chore: only run devp2p sim with clients that support snap sync

### DIFF
--- a/.github/workflows/sim-devp2p.yaml
+++ b/.github/workflows/sim-devp2p.yaml
@@ -19,6 +19,7 @@ jobs:
               ref: 'master',
               inputs: {
                 simulator: '["devp2p"]',
+                client: '["besu", "ethrex", "go-ethereum", "nethermind"]',
                 concurrency_group: 'devp2p',
                 timeout_minutes: '60'
               }


### PR DESCRIPTION
Erigon requested that they get removed from this dashboard as they don't support snapsync, so it makes little sense to test it. 

Removed erigon, reth and nimbus-el (support pending).

https://hive.ethpandaops.io/#/group/generic?suites=snap

<img width="2101" height="716" alt="image" src="https://github.com/user-attachments/assets/e1cc585a-8660-4202-b4c0-b26d8008fc92" />
