### PR TITLE
Update EELS build args to version bal@v7.3.1

### DIFF
--- a/.github/workflows/hive-devnet-7-quick.yaml
+++ b/.github/workflows/hive-devnet-7-quick.yaml
@@ -121,8 +121,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.2.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.2.0/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.3.1
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.3.1/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-devnet-7.yaml
+++ b/.github/workflows/hive-devnet-7.yaml
@@ -157,8 +157,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.2.0
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.2.0/fixtures_bal.tar.gz"
+      # Hardcoded EELS build args pinned to bal@v7.3.1
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.3.1/fixtures_bal.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
Bumps BAL devnet-7 fixtures from tests-bal@v7.2.0 to tests-bal@v7.3.1 in both hive-devnet-7 workflows. Release tracker: https://github.com/ethereum/execution-specs/issues/2979