### PR TITLE
chore(hive): point workflows at glamsterdam-devnet-6

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
@@ -82,7 +82,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
+    --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -90,7 +90,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
+    --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*'
     --sim.limit.exact=false
     --sim.loglevel=3
 

--- a/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
@@ -1,9 +1,8 @@
-name: Hive - BAL Devnet 7
+name: Hive - Glamsterdam Devnet 6 Quick
 on:
   schedule:
-    - cron: "45 13 * * *"
+    - cron: "45 12 * * *"
   workflow_dispatch:
-    # Note: We're limited to 10 inputs
     inputs:
       client:
         type: string
@@ -11,18 +10,19 @@ on:
         description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex
       simulator:
         type: string
-        # TODO: add back "ethereum/eels/consume-rlp"
+        # TODO: add back "ethereum/eels/consume-rlp" when clients have glamsterdam-devnet-6 branch
         default: >-
           "ethereum/eels/consume-engine"
         description: >-
           Comma-separated list of simulators to test
-          .e.g ethereum/rpc-compat, ethereum/eels/consume-engine, ethereum/eels/consume-rlp, ethereum/eels/execute-blobs
+          .e.g ethereum/eels/consume-engine, ethereum/eels/consume-rlp
       hive_version:
         type: string
         default: ethereum/hive@master
         description: GitHub repository and tag for hive (repo@tag)
       client_source:
         type: choice
+        default: docker
         description: >-
           How client images should be sourced.
           'git' will use the github repo and tag (See client_repos).
@@ -34,7 +34,7 @@ on:
         type: string
         description: >-
           If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
-        default: "bal-devnet-7"
+        default: "glamsterdam-devnet-6"
       client_repos:
         type: string
         default: |
@@ -67,8 +67,8 @@ env:
   GOPROXY: "${{ vars.GOPROXY }}"
   # Hive action environment variables
   S3_BUCKET: hive-results
-  S3_PATH: bal
-  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/bal/
+  S3_PATH: glamsterdam-quick
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/glamsterdam-quick/
   INSTALL_RCLONE_VERSION: v1.68.2
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
@@ -82,7 +82,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
+    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -90,76 +90,40 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
+    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
     --sim.limit.exact=false
-    --sim.loglevel=3
-  # Flags used for the ethereum/eels/execute simulator
-  EELS_EXECUTE_FLAGS: >-
-    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-  # Flags used for the ethereum/rpc-compat simulator
-  RPC_COMPAT_FLAGS: >-
     --sim.loglevel=3
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      # Hive version
-      hive_repo: >-
-        ${{
-          steps.client_config_schedule.outputs.hive_repo ||
-          steps.client_config_dispatch.outputs.hive_repo
-        }}
-      hive_tag: >-
-        ${{
-          steps.client_config_schedule.outputs.hive_tag ||
-          steps.client_config_dispatch.outputs.hive_tag
-        }}
-      # client_config contains the YAML client config for Hive
-      client_config: >-
-        ${{
-          steps.client_config_schedule.outputs.client_config ||
-          steps.client_config_dispatch.outputs.client_config
-        }}
-      # client_source to determine if we need docker auth
-      client_source: >-
-        ${{
-          github.event_name == 'schedule' && 'git' ||
-          inputs.client_source
-        }}
+      hive_repo: ${{ steps.client_config.outputs.hive_repo }}
+      hive_tag: ${{ steps.client_config.outputs.hive_tag }}
+      client_config: ${{ steps.client_config.outputs.client_config }}
+      client_source: ${{ inputs.client_source || 'git' }}
     steps:
       - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        if: github.event_name == 'schedule'
-        name: "Client config: schedule"
-        id: client_config_schedule
-        with:
-          common_client_tag: "bal-devnet-7"
-          client_source: "git"
-          hive_version: "ethereum/hive@master"
-          goproxy: ${{ env.GOPROXY }}
-
-      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        if: github.event_name == 'workflow_dispatch'
-        name: "Client config: workflow_dispatch"
-        id: client_config_dispatch
+        name: "Client config"
+        id: client_config
         with:
           client_repos: ${{ inputs.client_repos }}
           client_images: ${{ inputs.client_images }}
-          common_client_tag: ${{ inputs.common_client_tag }}
-          client_source: ${{ inputs.client_source }}
-          hive_version: ${{ inputs.hive_version }}
+          common_client_tag: ${{ inputs.common_client_tag || 'glamsterdam-devnet-6' }}
+          client_source: ${{ inputs.client_source || 'git' }}
+          hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
           goproxy: ${{ env.GOPROXY }}
 
   test:
-    timeout-minutes: 4320
+    timeout-minutes: 2160
     needs: prepare
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.3.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.3.1/fixtures_bal.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
+      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{
         matrix.simulator == 'ethereum/rpc-compat' && 'ubuntu-latest' ||
@@ -168,24 +132,24 @@ jobs:
       }}
     concurrency:
       group: >-
-        ${{ github.head_ref || inputs || github.workflow }}-${{ matrix.client }}-${{ matrix.simulator }}
+        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}-quick
     strategy:
       fail-fast: false
       matrix:
         client: >-
           ${{ fromJSON(format('[{0}]', inputs.client || '
-            "besu",
             "go-ethereum",
             "nethermind",
-            "reth",
             "nimbus-el",
             "erigon",
+            "besu",
+            "reth",
             "ethrex"
           '))}}
+        # TODO: add back "ethereum/eels/consume-rlp" when clients have glamsterdam-devnet-6 branch
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '
-            "ethereum/eels/consume-engine",
-            "ethereum/eels/consume-rlp"
+            "ethereum/eels/consume-engine"
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/hive-glamsterdam-devnet-6.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6.yaml
@@ -1,8 +1,9 @@
-name: Hive - BAL Devnet 7 Quick
+name: Hive - Glamsterdam Devnet 6
 on:
   schedule:
-    - cron: "45 12 * * *"
+    - cron: "45 13 * * *"
   workflow_dispatch:
+    # Note: We're limited to 10 inputs
     inputs:
       client:
         type: string
@@ -10,19 +11,18 @@ on:
         description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex
       simulator:
         type: string
-        # TODO: add back "ethereum/eels/consume-rlp" when clients have bal-devnet-7 branch
+        # TODO: add back "ethereum/eels/consume-rlp"
         default: >-
           "ethereum/eels/consume-engine"
         description: >-
           Comma-separated list of simulators to test
-          .e.g ethereum/eels/consume-engine, ethereum/eels/consume-rlp
+          .e.g ethereum/rpc-compat, ethereum/eels/consume-engine, ethereum/eels/consume-rlp, ethereum/eels/execute-blobs
       hive_version:
         type: string
         default: ethereum/hive@master
         description: GitHub repository and tag for hive (repo@tag)
       client_source:
         type: choice
-        default: docker
         description: >-
           How client images should be sourced.
           'git' will use the github repo and tag (See client_repos).
@@ -34,7 +34,7 @@ on:
         type: string
         description: >-
           If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
-        default: "bal-devnet-7"
+        default: "glamsterdam-devnet-6"
       client_repos:
         type: string
         default: |
@@ -67,8 +67,8 @@ env:
   GOPROXY: "${{ vars.GOPROXY }}"
   # Hive action environment variables
   S3_BUCKET: hive-results
-  S3_PATH: bal-quick
-  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/bal-quick/
+  S3_PATH: glamsterdam
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/glamsterdam/
   INSTALL_RCLONE_VERSION: v1.68.2
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
@@ -82,7 +82,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
+    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -90,40 +90,76 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*(7708|7778|7843|7928|7954|7976|7981|8024|8037).*'
+    --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
     --sim.limit.exact=false
+    --sim.loglevel=3
+  # Flags used for the ethereum/eels/execute simulator
+  EELS_EXECUTE_FLAGS: >-
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+  # Flags used for the ethereum/rpc-compat simulator
+  RPC_COMPAT_FLAGS: >-
     --sim.loglevel=3
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      hive_repo: ${{ steps.client_config.outputs.hive_repo }}
-      hive_tag: ${{ steps.client_config.outputs.hive_tag }}
-      client_config: ${{ steps.client_config.outputs.client_config }}
-      client_source: ${{ inputs.client_source || 'git' }}
+      # Hive version
+      hive_repo: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_repo ||
+          steps.client_config_dispatch.outputs.hive_repo
+        }}
+      hive_tag: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_tag ||
+          steps.client_config_dispatch.outputs.hive_tag
+        }}
+      # client_config contains the YAML client config for Hive
+      client_config: >-
+        ${{
+          steps.client_config_schedule.outputs.client_config ||
+          steps.client_config_dispatch.outputs.client_config
+        }}
+      # client_source to determine if we need docker auth
+      client_source: >-
+        ${{
+          github.event_name == 'schedule' && 'git' ||
+          inputs.client_source
+        }}
     steps:
       - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        name: "Client config"
-        id: client_config
+        if: github.event_name == 'schedule'
+        name: "Client config: schedule"
+        id: client_config_schedule
+        with:
+          common_client_tag: "glamsterdam-devnet-6"
+          client_source: "git"
+          hive_version: "ethereum/hive@master"
+          goproxy: ${{ env.GOPROXY }}
+
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: github.event_name == 'workflow_dispatch'
+        name: "Client config: workflow_dispatch"
+        id: client_config_dispatch
         with:
           client_repos: ${{ inputs.client_repos }}
           client_images: ${{ inputs.client_images }}
-          common_client_tag: ${{ inputs.common_client_tag || 'bal-devnet-7' }}
-          client_source: ${{ inputs.client_source || 'git' }}
-          hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
+          common_client_tag: ${{ inputs.common_client_tag }}
+          client_source: ${{ inputs.client_source }}
+          hive_version: ${{ inputs.hive_version }}
           goproxy: ${{ env.GOPROXY }}
 
   test:
-    timeout-minutes: 2160
+    timeout-minutes: 4320
     needs: prepare
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to bal@v7.3.1
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-bal@v7.3.1/fixtures_bal.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/bal/7"
+      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{
         matrix.simulator == 'ethereum/rpc-compat' && 'ubuntu-latest' ||
@@ -132,24 +168,24 @@ jobs:
       }}
     concurrency:
       group: >-
-        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}-quick
+        ${{ github.head_ref || inputs || github.workflow }}-${{ matrix.client }}-${{ matrix.simulator }}
     strategy:
       fail-fast: false
       matrix:
         client: >-
           ${{ fromJSON(format('[{0}]', inputs.client || '
+            "besu",
             "go-ethereum",
             "nethermind",
+            "reth",
             "nimbus-el",
             "erigon",
-            "besu",
-            "reth",
             "ethrex"
           '))}}
-        # TODO: add back "ethereum/eels/consume-rlp" when clients have bal-devnet-7 branch
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '
-            "ethereum/eels/consume-engine"
+            "ethereum/eels/consume-engine",
+            "ethereum/eels/consume-rlp"
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Renames the BAL devnet-7 quick/full Hive workflows to **glamsterdam-devnet-6** and retargets them at the [Glamsterdam Devnet 6 spec](https://notes.ethereum.org/@ethpandaops/glamsterdam-devnet-6).

## Changes (both workflows)
| Field | Before | After |
|---|---|---|
| file | `hive-devnet-7[-quick].yaml` | `hive-glamsterdam-devnet-6[-quick].yaml` |
| `name:` | Hive - BAL Devnet 7 [Quick] | Hive - Glamsterdam Devnet 6 [Quick] |
| `common_client_tag` | `bal-devnet-7` | `glamsterdam-devnet-6` |
| `S3_PATH` / public URL | `bal` / `bal-quick` | `glamsterdam` / `glamsterdam-quick` |
| `EELS_BUILD_ARG_FIXTURES` | `tests-bal@v7.3.1/fixtures_bal.tar.gz` | `tests-glamsterdam-devnet@v6.0.0/fixtures_glamsterdam-devnet.tar.gz` |
| `EELS_BUILD_ARG_BRANCH` | `devnets/bal/7` | `devnets/glamsterdam/6` |

`HIVE_AMSTERDAM_TIMESTAMP` is left unchanged (`1777456800`) — the spec sheet publishes no new genesis/fork timestamp.

## Quick-workflow `--sim.limit`
Expanded the consume-engine/consume-rlp EIP filter from the bal-devnet-7 set to the full glamsterdam-devnet-6 EIP set per the spec sheet:

`2780, 7708, 7732, 7778, 7843, 7928, 7954, 7975, 7976, 7981, 7997, 8024, 8037, 8038, 8045, 8061, 8070, 8159, 8246, 8282`

All 9 previously-listed EIPs are retained; the 11 new ones (incl. ePBS `7732` and repricing `2780`/`8038`) are added. The full workflow filters by fork (`fork_Amsterdam`) and already covers every new EIP, so its `--sim.limit` is left unchanged.

## ⚠️ EELS artifacts are WIP — runs will be red until ~2026-06-22
Per EELS tracker ethereum/execution-specs#2915, the glamsterdam-devnet-6 fixtures are planned for **2026-06-22**. As of opening this PR, none exist yet:
- `devnets/glamsterdam/6` branch — **not created**
- `tests-glamsterdam-devnet@v6.0.0` release — **not published**
- `fixtures_glamsterdam-devnet.tar.gz` asset name — **inferred** from the `tests-<feature>` → `fixtures_<feature>` convention (verified across `bal`/`zkevm`/`benchmark`), to be re-confirmed once the release is cut.

This PR intentionally pre-pins the target values so the workflows go green automatically once EELS publishes. If the final tag or asset name differs, it's a one-line fix per file.

## Open items to confirm
- **EIP-7610** (Revert creation for non-empty storage) is listed in tracker #2915 but not in the spec-sheet EIP list, so it was **not** added to the quick filter — add it?
- Full-workflow fork filter still includes `Osaka` / `BPO2ToAmsterdamAtTime15k`; the spec sheet lists no Osaka/BPO forks for devnet-6 — prune them?