### PR TITLE
chore(glamsterdam): bump EELS fixtures to tests-glamsterdam-devnet@v6.0.1

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
@@ -121,8 +121,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.1 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-6.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6.yaml
@@ -157,8 +157,8 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.0.1 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.0.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{


### PR DESCRIPTION
Bumps the hardcoded EELS fixtures pin from `tests-glamsterdam-devnet@v6.0.0` to `v6.0.1` for the glamsterdam devnet-6 hive workflows.

Updated files:
- `.github/workflows/hive-glamsterdam-devnet-6.yaml`
- `.github/workflows/hive-glamsterdam-devnet-6-quick.yaml`

Both the `EELS_BUILD_ARG_FIXTURES` download URL and its accompanying comment now reference `v6.0.1`. The `EELS_BUILD_ARG_BRANCH` (`devnets/glamsterdam/6`) is unchanged.