### PR TITLE
chore: bump glamsterdam-devnet-6 fixtures to tests-glamsterdam-devnet@v6.1.1

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6-quick.yaml
@@ -121,8 +121,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.1.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.1.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-6.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-6.yaml
@@ -157,8 +157,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      # Hardcoded EELS build args pinned to tests-glamsterdam-devnet@v6.1.0 (release + branch pending ~2026-06-22, EELS tracker ethereum/execution-specs#2915)
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v6.1.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/6"
     runs-on: >-
       ${{


### PR DESCRIPTION
Bumps both glamsterdam-devnet-6 hive workflows to [tests-glamsterdam-devnet@v6.1.1](https://github.com/ethereum/execution-specs/releases/tag/tests-glamsterdam-devnet%40v6.1.1) (EELS tracker ethereum/execution-specs#3049).