### PR TITLE
chore: bump generic EELS fixtures to execution-specs tests@v20.0.0

### DIFF
--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -90,8 +90,8 @@ env:
   S3_PATH: generic
   S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/generic/
   INSTALL_RCLONE_VERSION: v1.68.2
-  EELS_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-spec-tests/releases/download/v5.3.0/fixtures_stable.tar.gz # Bump to develop soon (TM)
-  EELS_BUILD_ARG_BRANCH: forks/osaka
+  EELS_BUILD_ARG_FIXTURES: https://github.com/ethereum/execution-specs/releases/download/tests@v20.0.0/fixtures.tar.gz
+  EELS_BUILD_ARG_BRANCH: forks/amsterdam
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=180s


### PR DESCRIPTION
Bump mainnet release to latest EELS release [v20.0.0](https://github.com/ethereum/execution-specs/releases/tag/tests%40v20.0.0).