### PR TITLE
fix: install self-hosted runner deps in generate-index workflow

### DIFF
--- a/.github/workflows/generate-index.yaml
+++ b/.github/workflows/generate-index.yaml
@@ -27,6 +27,9 @@ jobs:
       cancel-in-progress: true
 
     steps:
+    - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+      if: runner.environment != 'github-hosted'
+
     - name: Run Index Generator
       uses: ethpandaops/hive-github-action@master # v0.6.0-unreleased
       with:


### PR DESCRIPTION
Every scheduled `generate-index` run since July 2 has failed with `unzip: not found`: the rclone tool-cache restore stopped working, and `setup-rclone`'s download fallback needs `unzip`, which the bare self-hosted runners don't have. This adds the same `self-hosted-runner-dependencies` helper step the other workflows already run before `hive-github-action`, leaving the `generic` results index stale no longer. Example failure: https://github.com/ethpandaops/hive-tests/actions/runs/28970491254/job/85964655176