### PR TITLE
chore: enable all clients with the enginex simulator

### DIFF
--- a/.github/workflows/sim-ethereum-eels-consume-enginex.yaml
+++ b/.github/workflows/sim-ethereum-eels-consume-enginex.yaml
@@ -19,7 +19,6 @@ jobs:
               ref: 'master',
               inputs: {
                 simulator: '["ethereum/eels/consume-enginex"]',
-                client: '["besu", "ethrex", "go-ethereum", "nethermind", "nimbus-el", "reth"]',
                 concurrency_group: 'eels-consume-enginex',
                 timeout_minutes: '1680'
               }


### PR DESCRIPTION
Enables runs for all EL clients with the enginex simulator.