### PR TITLE
Update Glamsterdam devnet 7 tests to v7.1

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-7-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-7-quick.yaml
@@ -121,7 +121,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.1.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-7.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-7.yaml
@@ -157,7 +157,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.1.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
Updates the Glamsterdam devnet 7 EELS fixture release from tests-glamsterdam-devnet@v7.0.0 to tests-glamsterdam-devnet@v7.1.0 in both the full and quick Hive workflows.