### PR TITLE
chore(hive): bump glamsterdam-devnet fixtures to v7.2.0

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-7-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-7-quick.yaml
@@ -121,7 +121,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.2.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/7"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-7.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-7.yaml
@@ -157,7 +157,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v7.2.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/7"
     runs-on: >-
       ${{


### PR DESCRIPTION
Pins the glamsterdam-devnet-7 workflows to `tests-glamsterdam-devnet@v7.2.0`, which adds the EIP-8037 calldata-floor block-gas change (ethereum/EIPs#11908). Release pending, tracker ethereum/execution-specs#3147.