### PR TITLE
feat(workflows): add per-client-and-simulator job timeout override

### DIFF
--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -80,6 +80,14 @@ on:
         type: string
         default: "2880"
         description: "Timeout in minutes for the test job (default: 2880 = 2 days)"
+      client_timeout_overrides:
+        type: string
+        default: '{ "besu": { "ethereum/eels/consume-engine": 2880 } }'
+        description: >-
+          JSON object mapping client name to simulator to a job timeout in
+          minutes that takes precedence over timeout_minutes for that
+          client and simulator (besu needs ~35h for eels/consume-engine,
+          more than the 28h the daily triggers allow)
 
 
 env:
@@ -145,7 +153,7 @@ jobs:
           goproxy: ${{ env.GOPROXY }}
 
   test:
-    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
+    timeout-minutes: ${{ fromJSON(inputs.client_timeout_overrides)[matrix.client][matrix.simulator] || fromJSON(inputs.timeout_minutes) }}
     needs: prepare
     runs-on: >-
       ${{


### PR DESCRIPTION
I'd love to get a full Besu run in with `consume-engine` in order to benchmark it against `consume-enginex`. 

Apparently, GitHub only allows at most one running + one pending job (pending N+1 jobs get replaced by a pending N+2 job), so the Besu jobs shouldn't pile up (if not they would: the job runs daily and the job takes > 36 hours. 

Besu needs ~35h for `eels/consume-engine` (~1,460 tests/h over 50,564 tests), more than the 28h the daily triggers allow, so its job is always killed before the suite results upload; this adds a `client_timeout_overrides` input defaulting to 48h for besu on `ethereum/eels/consume-engine` only, leaving all other clients and simulators on the trigger-supplied timeout.
