### PR TITLE
chore(hive): run execute-blobs at Amsterdam on devnet-8

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -97,6 +97,7 @@ env:
   # Flags used for the ethereum/eels/execute-blobs simulator
   EELS_EXECUTE_FLAGS: >-
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.buildarg fork=Amsterdam
     --sim.loglevel=3
   # Flags used for the ethereum/rpc-compat simulator
   RPC_COMPAT_FLAGS: >-


### PR DESCRIPTION
The execute-blobs sim Dockerfile defaults to `fork=Osaka`, so the EIP-8070 sparse blobpool tests (ethereum/execution-specs#2948, `valid_from("EIP8070")`) are deselected on devnet-8 runs. Pass `fork=Amsterdam` explicitly; the Osaka-era blob tests have no `valid_until` cap so they still collect at Amsterdam.