### PR TITLE
chore(hive): bump devnet-8 fixtures to glamsterdam-devnet@v8.1.0

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -121,7 +121,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/8"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -160,7 +160,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.0.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.0/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/8"
     runs-on: >-
       ${{


### PR DESCRIPTION
Points both devnet-8 workflows at the `tests-glamsterdam-devnet@v8.1.0` fixtures release (ethereum/execution-specs#3295), cut from `devnets/glamsterdam/8` with the revised EIP-8038 values and the Engine X fill fixes. Release run in flight: https://github.com/ethereum/execution-specs/actions/runs/31000320488