### PR TITLE
feat(hive): add eels client to devnet-8 workflows

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -6,8 +6,8 @@ on:
     inputs:
       client:
         type: string
-        default: '"go-ethereum","nethermind","nimbus-el","erigon","besu","reth","ethrex"'
-        description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex
+        default: '"go-ethereum","nethermind","nimbus-el","erigon","besu","reth","ethrex","eels"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex, eels
       simulator:
         type: string
         default: >-
@@ -85,6 +85,15 @@ env:
     --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*'
     --sim.limit.exact=false
     --sim.loglevel=3
+  # Flags used for the ethereum/eels/consume-engine simulator when the
+  # client is EELS itself (only supports running Amsterdam from genesis)
+  EELS_ENGINE_FLAGS_EELS_CLIENT: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*fork_Amsterdam-.*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
   EELS_RLP_FLAGS: >-
     --sim.parallelism=6
@@ -150,6 +159,9 @@ jobs:
             "ethereum/eels/consume-engine",
             "ethereum/eels/consume-rlp"
           '))}}
+        exclude:
+          - client: eels
+            simulator: ethereum/eels/consume-rlp
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
@@ -168,7 +180,7 @@ jobs:
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
             ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
-            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && (matrix.client == 'eels' && env.EELS_ENGINE_FLAGS_EELS_CLIENT || env.EELS_ENGINE_FLAGS) || '' }}
             ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
           s3_upload: true
           s3_bucket: ${{ env.S3_BUCKET }}

--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -85,15 +85,6 @@ env:
     --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*'
     --sim.limit.exact=false
     --sim.loglevel=3
-  # Flags used for the ethereum/eels/consume-engine simulator when the
-  # client is EELS itself (only supports running Amsterdam from genesis)
-  EELS_ENGINE_FLAGS_EELS_CLIENT: >-
-    --sim.parallelism=6
-    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
-    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*(2780|7708|7732|7778|7843|7928|7954|7975|7976|7981|7997|8024|8037|8038|8045|8061|8070|8159|8246|8282).*fork_Amsterdam-.*'
-    --sim.limit.exact=false
-    --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
   EELS_RLP_FLAGS: >-
     --sim.parallelism=6
@@ -180,7 +171,7 @@ jobs:
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
             ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
-            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && (matrix.client == 'eels' && env.EELS_ENGINE_FLAGS_EELS_CLIENT || env.EELS_ENGINE_FLAGS) || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
           s3_upload: true
           s3_bucket: ${{ env.S3_BUCKET }}

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -7,8 +7,8 @@ on:
     inputs:
       client:
         type: string
-        default: '"go-ethereum","nethermind","nimbus-el","erigon","besu","reth","ethrex"'
-        description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex
+        default: '"go-ethereum","nethermind","nimbus-el","erigon","besu","reth","ethrex","eels"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, besu, reth, nethermind, erigon, nimbus-el, ethrex, eels
       simulator:
         type: string
         default: >-
@@ -84,6 +84,15 @@ env:
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
     --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
+  # Flags used for the ethereum/eels/consume-engine simulator when the
+  # client is EELS itself (only supports running Amsterdam from genesis)
+  EELS_ENGINE_FLAGS_EELS_CLIENT: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*fork_Amsterdam-.*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -182,7 +191,8 @@ jobs:
             "reth",
             "nimbus-el",
             "erigon",
-            "ethrex"
+            "ethrex",
+            "eels"
           '))}}
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '
@@ -190,6 +200,11 @@ jobs:
             "ethereum/eels/consume-rlp",
             "ethereum/eels/execute-blobs"
           '))}}
+        exclude:
+          - client: eels
+            simulator: ethereum/eels/consume-rlp
+          - client: eels
+            simulator: ethereum/eels/execute-blobs
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
@@ -208,7 +223,7 @@ jobs:
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
             ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
-            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && (matrix.client == 'eels' && env.EELS_ENGINE_FLAGS_EELS_CLIENT || env.EELS_ENGINE_FLAGS) || '' }}
             ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eels/execute-blobs' && env.EELS_EXECUTE_FLAGS || '' }}
           s3_upload: true

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -86,15 +86,6 @@ env:
     --sim.limit='.*fork_(Amsterdam|BPO2ToAmsterdamAtTime15k|Osaka).*'
     --sim.limit.exact=false
     --sim.loglevel=3
-  # Flags used for the ethereum/eels/consume-engine simulator when the
-  # client is EELS itself (only supports running Amsterdam from genesis)
-  EELS_ENGINE_FLAGS_EELS_CLIENT: >-
-    --sim.parallelism=6
-    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
-    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*fork_Amsterdam-.*'
-    --sim.limit.exact=false
-    --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
   EELS_RLP_FLAGS: >-
     --sim.parallelism=6
@@ -223,7 +214,7 @@ jobs:
           extra_flags: >-
             ${{ env.GLOBAL_EXTRA_FLAGS }}
             ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
-            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && (matrix.client == 'eels' && env.EELS_ENGINE_FLAGS_EELS_CLIENT || env.EELS_ENGINE_FLAGS) || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
             ${{ matrix.simulator == 'ethereum/eels/execute-blobs' && env.EELS_EXECUTE_FLAGS || '' }}
           s3_upload: true


### PR DESCRIPTION
Adds `eels` as a client to both devnet-8 workflows: EELS runs the
execution spec itself behind the Engine API, so `consume engine`
validates the fixtures directly against the spec that filled them.

- `eels` added to the client matrix and dispatch defaults.
- Own consume-engine flags (`EELS_ENGINE_FLAGS_EELS_CLIENT`): the
  shared `--sim.limit` includes Osaka and the BPO2→Amsterdam
  transition, which the eels client refuses by design (Amsterdam from
  genesis only), so its rows run `.*fork_Amsterdam-.*` (quick:
  combined with the EIP filter).
- Excluded from `consume-rlp` (no `/chain.rlp` import) and
  `execute-blobs` (no transaction submission).
- No `client_repos`/`client_images` entries: the client builds from
  its Dockerfile defaults in hive, so `common_client_tag` does not
  apply to it.

Verified locally against `glamsterdam-devnet@v8.1.0` (consume-engine,
`.*fork_Amsterdam-.*`): 0 failures so far in an in-progress 24,819-test
sweep; a 136-test subset passed 136/136.

Draft until the client lands in hive (ethereum/hive#1596, which itself
follows ethereum/execution-specs#3363).
