### PR TITLE
feat(hive): add frames-devnet-0 workflows (consume engine/rlp only)

### DIFF
--- a/.github/workflows/hive-frames-devnet-0-quick.yaml
+++ b/.github/workflows/hive-frames-devnet-0-quick.yaml
@@ -1,0 +1,167 @@
+name: Hive - Frames Devnet 0 Quick
+on:
+  schedule:
+    - cron: "45 14 * * *"
+  workflow_dispatch:
+    inputs:
+      client:
+        type: string
+        default: '"go-ethereum","nethermind","ethrex"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, nethermind, ethrex
+      simulator:
+        type: string
+        default: >-
+          "ethereum/eels/consume-engine",
+          "ethereum/eels/consume-rlp"
+        description: >-
+          Comma-separated list of simulators to test
+          .e.g ethereum/eels/consume-engine, ethereum/eels/consume-rlp
+      hive_version:
+        type: string
+        default: ethereum/hive@master
+        description: GitHub repository and tag for hive (repo@tag)
+      client_source:
+        type: choice
+        default: docker
+        description: >-
+          How client images should be sourced.
+          'git' will use the github repo and tag (See client_repos).
+          'docker' will use the docker registry and tag (See client_images).
+        options:
+          - docker
+          - git
+      common_client_tag:
+        type: string
+        description: >-
+          If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
+        default: "frames-devnet-0"
+      client_repos:
+        type: string
+        default: |
+          {
+            "geth": "ethereum/go-ethereum@master",
+            "nethermind": "NethermindEth/nethermind@master",
+            "ethrex": "lambdaclass/ethrex@main"
+          }
+        description: 'JSON object containing client versions in format {"client": "repo@tag", ...}'
+      client_images:
+        type: string
+        default: |
+          {
+            "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
+            "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
+            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
+          }
+        description: 'JSON object containing client docker images in format {"client": "registry:tag", ...}'
+
+env:
+  # Proxy
+  GOPROXY: "${{ vars.GOPROXY }}"
+  # Hive action environment variables
+  S3_BUCKET: hive-results
+  S3_PATH: frames-quick
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/frames-quick/
+  INSTALL_RCLONE_VERSION: v1.68.2
+  # Flags used for all simulators
+  GLOBAL_EXTRA_FLAGS: >-
+    --client.checktimelimit=300s
+    --docker.buildoutput
+  # Docker-specific flags (only used when client_source is 'docker')
+  DOCKER_AUTH_FLAGS: >-
+    --docker.auth
+  # Flags used for the ethereum/eels/consume-engine simulator
+  EELS_ENGINE_FLAGS: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*8141.*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
+  # Flags used for the ethereum/eels/consume-rlp simulator
+  EELS_RLP_FLAGS: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*8141.*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      hive_repo: ${{ steps.client_config.outputs.hive_repo }}
+      hive_tag: ${{ steps.client_config.outputs.hive_tag }}
+      client_config: ${{ steps.client_config.outputs.client_config }}
+      client_source: ${{ inputs.client_source || 'git' }}
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        name: "Client config"
+        id: client_config
+        with:
+          client_repos: ${{ inputs.client_repos }}
+          client_images: ${{ inputs.client_images }}
+          common_client_tag: ${{ inputs.common_client_tag || 'frames-devnet-0' }}
+          client_source: ${{ inputs.client_source || 'git' }}
+          hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
+          goproxy: ${{ env.GOPROXY }}
+
+  test:
+    timeout-minutes: 2160
+    needs: prepare
+    env:
+      # BAL-specific environment variables
+      HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
+      HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
+    runs-on: >-
+      ${{
+        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-xl-do-x64' ||
+        'ubuntu-latest'
+      }}
+    concurrency:
+      group: >-
+        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}-quick
+    strategy:
+      fail-fast: false
+      matrix:
+        client: >-
+          ${{ fromJSON(format('[{0}]', inputs.client || '
+            "go-ethereum",
+            "nethermind",
+            "ethrex"
+          '))}}
+        simulator: >-
+          ${{ fromJSON(format('[{0}]', inputs.simulator || '
+            "ethereum/eels/consume-engine",
+            "ethereum/eels/consume-rlp"
+          '))}}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d
+        with:
+          username: ethpandaops
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          hive_repository: ${{ needs.prepare.outputs.hive_repo }}
+          hive_version: ${{ needs.prepare.outputs.hive_tag }}
+          client: ${{ matrix.client }}
+          simulator: ${{ matrix.simulator }}
+          client_config: ${{ needs.prepare.outputs.client_config }}
+          extra_flags: >-
+            ${{ env.GLOBAL_EXTRA_FLAGS }}
+            ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          s3_public_url: ${{ env.S3_PUBLIC_URL }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          workflow_artifact_upload: true
+          website_upload: true

--- a/.github/workflows/hive-frames-devnet-0.yaml
+++ b/.github/workflows/hive-frames-devnet-0.yaml
@@ -1,0 +1,197 @@
+name: Hive - Frames Devnet 0
+on:
+  schedule:
+    - cron: "45 15 * * *"
+  workflow_dispatch:
+    # Note: We're limited to 10 inputs
+    inputs:
+      client:
+        type: string
+        default: '"go-ethereum","nethermind","ethrex"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, nethermind, ethrex
+      simulator:
+        type: string
+        default: >-
+          "ethereum/eels/consume-engine",
+          "ethereum/eels/consume-rlp"
+        description: >-
+          Comma-separated list of simulators to test
+          .e.g ethereum/eels/consume-engine, ethereum/eels/consume-rlp
+      hive_version:
+        type: string
+        default: ethereum/hive@master
+        description: GitHub repository and tag for hive (repo@tag)
+      client_source:
+        type: choice
+        description: >-
+          How client images should be sourced.
+          'git' will use the github repo and tag (See client_repos).
+          'docker' will use the docker registry and tag (See client_images).
+        options:
+          - docker
+          - git
+      common_client_tag:
+        type: string
+        description: >-
+          If provided, this tag will be used for all clients, overriding individual tags/branches in client_repos and client_images
+        default: "frames-devnet-0"
+      client_repos:
+        type: string
+        default: |
+          {
+            "geth": "ethereum/go-ethereum@master",
+            "nethermind": "NethermindEth/nethermind@master",
+            "ethrex": "lambdaclass/ethrex@main"
+          }
+        description: 'JSON object containing client versions in format {"client": "repo@tag", ...}'
+      client_images:
+        type: string
+        default: |
+          {
+            "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
+            "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
+            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
+          }
+        description: 'JSON object containing client docker images in format {"client": "registry:tag", ...}'
+
+env:
+  # Proxy
+  GOPROXY: "${{ vars.GOPROXY }}"
+  # Hive action environment variables
+  S3_BUCKET: hive-results
+  S3_PATH: frames
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/frames/
+  INSTALL_RCLONE_VERSION: v1.68.2
+  # Flags used for all simulators
+  GLOBAL_EXTRA_FLAGS: >-
+    --client.checktimelimit=300s
+    --docker.buildoutput
+  # Docker-specific flags (only used when client_source is 'docker')
+  DOCKER_AUTH_FLAGS: >-
+    --docker.auth
+  # Flags used for the ethereum/eels/consume-engine simulator
+  EELS_ENGINE_FLAGS: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*fork_Bogota.*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
+  # Flags used for the ethereum/eels/consume-rlp simulator
+  EELS_RLP_FLAGS: >-
+    --sim.parallelism=6
+    --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
+    --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
+    --sim.limit='.*fork_Bogota.*'
+    --sim.limit.exact=false
+    --sim.loglevel=3
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      # Hive version
+      hive_repo: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_repo ||
+          steps.client_config_dispatch.outputs.hive_repo
+        }}
+      hive_tag: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_tag ||
+          steps.client_config_dispatch.outputs.hive_tag
+        }}
+      # client_config contains the YAML client config for Hive
+      client_config: >-
+        ${{
+          steps.client_config_schedule.outputs.client_config ||
+          steps.client_config_dispatch.outputs.client_config
+        }}
+      # client_source to determine if we need docker auth
+      client_source: >-
+        ${{
+          github.event_name == 'schedule' && 'git' ||
+          inputs.client_source
+        }}
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: github.event_name == 'schedule'
+        name: "Client config: schedule"
+        id: client_config_schedule
+        with:
+          common_client_tag: "frames-devnet-0"
+          client_source: "git"
+          hive_version: "ethereum/hive@master"
+          goproxy: ${{ env.GOPROXY }}
+
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: github.event_name == 'workflow_dispatch'
+        name: "Client config: workflow_dispatch"
+        id: client_config_dispatch
+        with:
+          client_repos: ${{ inputs.client_repos }}
+          client_images: ${{ inputs.client_images }}
+          common_client_tag: ${{ inputs.common_client_tag }}
+          client_source: ${{ inputs.client_source }}
+          hive_version: ${{ inputs.hive_version }}
+          goproxy: ${{ env.GOPROXY }}
+
+  test:
+    timeout-minutes: 4320
+    needs: prepare
+    env:
+      # BAL-specific environment variables
+      HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
+      HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
+    runs-on: >-
+      ${{
+        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-ccx33-x64' ||
+        'ubuntu-latest'
+      }}
+    concurrency:
+      group: >-
+        ${{ github.head_ref || inputs || github.workflow }}-${{ matrix.client }}-${{ matrix.simulator }}
+    strategy:
+      fail-fast: false
+      matrix:
+        client: >-
+          ${{ fromJSON(format('[{0}]', inputs.client || '
+            "go-ethereum",
+            "nethermind",
+            "ethrex"
+          '))}}
+        simulator: >-
+          ${{ fromJSON(format('[{0}]', inputs.simulator || '
+            "ethereum/eels/consume-engine",
+            "ethereum/eels/consume-rlp"
+          '))}}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d
+        with:
+          username: ethpandaops
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          hive_repository: ${{ needs.prepare.outputs.hive_repo }}
+          hive_version: ${{ needs.prepare.outputs.hive_tag }}
+          client: ${{ matrix.client }}
+          simulator: ${{ matrix.simulator }}
+          client_config: ${{ needs.prepare.outputs.client_config }}
+          extra_flags: >-
+            ${{ env.GLOBAL_EXTRA_FLAGS }}
+            ${{ needs.prepare.outputs.client_source == 'docker' && env.DOCKER_AUTH_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-engine' && env.EELS_ENGINE_FLAGS || '' }}
+            ${{ matrix.simulator == 'ethereum/eels/consume-rlp' && env.EELS_RLP_FLAGS || '' }}
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          s3_public_url: ${{ env.S3_PUBLIC_URL }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          workflow_artifact_upload: true
+          website_upload: true


### PR DESCRIPTION
Adds the frames-devnet-0 workflow pair, mirroring the glamsterdam-devnet-8 workflows:

- consume-engine + consume-rlp only for now
- go-ethereum / nethermind / ethrex only
- `frames` runs the full `tests-frames-devnet@v0.0.0` fixture set (all tests filled at the Bogota pseudo-fork); `frames-quick` filters to the 8141 tests
- fixtures cut from [`devnets/frames/0`](https://github.com/ethereum/execution-specs/tree/devnets/frames/0) (release pending; scheduled runs fail until it lands)
- results: `frames` / `frames-quick`

Tracker: ethereum/execution-specs#3368
