### PR TITLE
fix(workflows): regenerate the results index once per run

### DIFF
--- a/.github/workflows/generate-index.yaml
+++ b/.github/workflows/generate-index.yaml
@@ -22,8 +22,20 @@ env:
 jobs:
   generate-index:
     runs-on: self-hosted-ghr-size-ccx33-x64
+    strategy:
+      fail-fast: false
+      matrix:
+        # Scheduled runs reindex every results path so uploads never wait on
+        # the per-run index job of a still-running workflow; dispatches
+        # reindex the requested path only.
+        s3_path: >-
+          ${{
+            github.event_name == 'schedule' &&
+            fromJSON('["generic", "glamsterdam", "glamsterdam-quick", "frames", "frames-quick"]') ||
+            fromJSON(format('["{0}"]', inputs.s3-path || 'generic'))
+          }}
     concurrency:
-      group: "generate-index-${{ inputs.s3-bucket || 'hive-results' }}-${{ inputs.s3-path || 'generic' }}"
+      group: "generate-index-${{ inputs.s3-bucket || 'hive-results' }}-${{ matrix.s3_path }}"
       cancel-in-progress: true
 
     steps:
@@ -36,9 +48,9 @@ jobs:
         skip_tests: true
         s3_upload: true
         s3_bucket: ${{ inputs.s3-bucket || 'hive-results' }}
-        s3_path: ${{ inputs.s3-path || 'generic' }}
+        s3_path: ${{ matrix.s3_path }}
         rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
         rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
         website_upload: false
-        website_listing_limit: '3000'
+        website_listing_limit: '5000'
         website_index_generation: true

--- a/.github/workflows/generate-index.yaml
+++ b/.github/workflows/generate-index.yaml
@@ -32,7 +32,7 @@ jobs:
           ${{
             github.event_name == 'schedule' &&
             fromJSON('["generic", "glamsterdam", "glamsterdam-quick", "frames", "frames-quick"]') ||
-            fromJSON(format('["{0}"]', inputs.s3-path || 'generic'))
+            fromJSON(format('[{0}]', toJSON(inputs.s3-path || 'generic')))
           }}
     concurrency:
       group: "generate-index-${{ inputs.s3-bucket || 'hive-results' }}-${{ matrix.s3_path }}"
@@ -43,7 +43,7 @@ jobs:
       if: runner.environment != 'github-hosted'
 
     - name: Run Index Generator
-      uses: ethpandaops/hive-github-action@master # v0.6.0-unreleased
+      uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
       with:
         skip_tests: true
         s3_upload: true

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -210,3 +210,25 @@ jobs:
           workflow_artifact_upload: ${{ inputs.workflow_artifact_upload }}
           website_upload: false
           website_index_generation: false
+
+  index:
+    needs: test
+    if: always()
+    runs-on: self-hosted-ghr-size-ccx33-x64
+    concurrency:
+      group: "generate-index-hive-results-generic"
+      cancel-in-progress: true
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          skip_tests: true
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          website_upload: false
+          website_listing_limit: '5000'
+          website_index_generation: true

--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -213,7 +213,9 @@ jobs:
 
   index:
     needs: test
-    if: always()
+    # not always(): index after failures (successful jobs uploaded results)
+    # but not after cancellation
+    if: ${{ !cancelled() }}
     runs-on: self-hosted-ghr-size-ccx33-x64
     concurrency:
       group: "generate-index-hive-results-generic"

--- a/.github/workflows/hive-frames-devnet-0-quick.yaml
+++ b/.github/workflows/hive-frames-devnet-0-quick.yaml
@@ -186,4 +186,5 @@ jobs:
           rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           website_upload: false
+          website_listing_limit: '5000'
           website_index_generation: true

--- a/.github/workflows/hive-frames-devnet-0-quick.yaml
+++ b/.github/workflows/hive-frames-devnet-0-quick.yaml
@@ -169,7 +169,9 @@ jobs:
 
   index:
     needs: test
-    if: always()
+    # not always(): index after failures (successful jobs uploaded results)
+    # but not after cancellation
+    if: ${{ !cancelled() }}
     runs-on: self-hosted-ghr-size-ccx33-x64
     concurrency:
       group: "generate-index-hive-results-frames-quick"

--- a/.github/workflows/hive-frames-devnet-0-quick.yaml
+++ b/.github/workflows/hive-frames-devnet-0-quick.yaml
@@ -165,3 +165,25 @@ jobs:
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           workflow_artifact_upload: true
           website_upload: true
+          website_index_generation: false
+
+  index:
+    needs: test
+    if: always()
+    runs-on: self-hosted-ghr-size-ccx33-x64
+    concurrency:
+      group: "generate-index-hive-results-frames-quick"
+      cancel-in-progress: true
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          skip_tests: true
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          website_upload: false
+          website_index_generation: true

--- a/.github/workflows/hive-frames-devnet-0.yaml
+++ b/.github/workflows/hive-frames-devnet-0.yaml
@@ -195,3 +195,25 @@ jobs:
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           workflow_artifact_upload: true
           website_upload: true
+          website_index_generation: false
+
+  index:
+    needs: test
+    if: always()
+    runs-on: self-hosted-ghr-size-ccx33-x64
+    concurrency:
+      group: "generate-index-hive-results-frames"
+      cancel-in-progress: true
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          skip_tests: true
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          website_upload: false
+          website_index_generation: true

--- a/.github/workflows/hive-frames-devnet-0.yaml
+++ b/.github/workflows/hive-frames-devnet-0.yaml
@@ -216,4 +216,5 @@ jobs:
           rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           website_upload: false
+          website_listing_limit: '5000'
           website_index_generation: true

--- a/.github/workflows/hive-frames-devnet-0.yaml
+++ b/.github/workflows/hive-frames-devnet-0.yaml
@@ -199,7 +199,9 @@ jobs:
 
   index:
     needs: test
-    if: always()
+    # not always(): index after failures (successful jobs uploaded results)
+    # but not after cancellation
+    if: ${{ !cancelled() }}
     runs-on: self-hosted-ghr-size-ccx33-x64
     concurrency:
       group: "generate-index-hive-results-frames"

--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -182,7 +182,9 @@ jobs:
 
   index:
     needs: test
-    if: always()
+    # not always(): index after failures (successful jobs uploaded results)
+    # but not after cancellation
+    if: ${{ !cancelled() }}
     runs-on: self-hosted-ghr-size-ccx33-x64
     concurrency:
       group: "generate-index-hive-results-glamsterdam-quick"

--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -199,4 +199,5 @@ jobs:
           rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           website_upload: false
+          website_listing_limit: '5000'
           website_index_generation: true

--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -178,3 +178,25 @@ jobs:
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           workflow_artifact_upload: true
           website_upload: true
+          website_index_generation: false
+
+  index:
+    needs: test
+    if: always()
+    runs-on: self-hosted-ghr-size-ccx33-x64
+    concurrency:
+      group: "generate-index-hive-results-glamsterdam-quick"
+      cancel-in-progress: true
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          skip_tests: true
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          website_upload: false
+          website_index_generation: true

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -223,7 +223,9 @@ jobs:
 
   index:
     needs: test
-    if: always()
+    # not always(): index after failures (successful jobs uploaded results)
+    # but not after cancellation
+    if: ${{ !cancelled() }}
     runs-on: self-hosted-ghr-size-ccx33-x64
     concurrency:
       group: "generate-index-hive-results-glamsterdam"

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -240,4 +240,5 @@ jobs:
           rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           website_upload: false
+          website_listing_limit: '5000'
           website_index_generation: true

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -219,3 +219,25 @@ jobs:
           rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
           workflow_artifact_upload: true
           website_upload: true
+          website_index_generation: false
+
+  index:
+    needs: test
+    if: always()
+    runs-on: self-hosted-ghr-size-ccx33-x64
+    concurrency:
+      group: "generate-index-hive-results-glamsterdam"
+      cancel-in-progress: true
+    steps:
+      - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: runner.environment != 'github-hosted'
+      - uses: ethpandaops/hive-github-action@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        with:
+          skip_tests: true
+          s3_upload: true
+          s3_bucket: ${{ env.S3_BUCKET }}
+          s3_path: ${{ env.S3_PATH }}
+          rclone_config: ${{ secrets.HIVE_RCLONE_CONFIG }}
+          rclone_version: ${{ env.INSTALL_RCLONE_VERSION }}
+          website_upload: false
+          website_index_generation: true


### PR DESCRIPTION
### Summary

Test runs no longer randomly disappear. The results index is rebuilt once per workflow run instead of by ~21 racing matrix jobs, so a finished run can't be overwritten out of the listing.

### Description

Every matrix job currently regenerates `listing.jsonl` at job end (fetch all suite JSONs from S3 → `hiveview --listing` → upload). With ~21 jobs per run the uploads race: last writer wins, and if its S3 snapshot predates another job's upload, that run disappears from the UI until the next regeneration.

This disables index generation on the matrix jobs and adds a single `needs: test, if: always()` index job per workflow, sharing a concurrency group with a `generate-index` dispatch for the same S3 path. Applied to the glamsterdam-devnet-8 and frames-devnet-0 workflows (same bug), and to `generic.yaml` — which never had the race (index generation is disabled there) but only got reindexed by the 3-hourly cron, so daily runs took up to 3h to appear.

Since the per-run index job only fires after the slowest matrix job (besu runs 20–31h), the `generate-index` cron now matrixes over all five results paths instead of just `generic`, capping index staleness at 3h for fast clients' uploads. The listing limit is raised to 5000 everywhere while at it — `generic` sits at ~2500 entries and would soon start silently dropping the oldest runs at the current 3000 cap.