### PR TITLE
chore(workflows): source scheduled devnet-8 clients from prebuilt images

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -70,6 +70,18 @@ env:
   S3_PATH: glamsterdam-quick
   S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/glamsterdam-quick/
   INSTALL_RCLONE_VERSION: v1.68.2
+  # Fallback for scheduled runs (no inputs); mirrors the workflow_dispatch
+  # default, incl. the ethpandaops ethrex image (helper defaults to ghcr.io).
+  DEFAULT_CLIENT_IMAGES: |
+    {
+      "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
+      "besu": "docker.ethquokkaops.io/dh/ethpandaops/besu:main",
+      "reth": "docker.ethquokkaops.io/dh/ethpandaops/reth:main",
+      "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
+      "erigon": "docker.ethquokkaops.io/dh/ethpandaops/erigon:main",
+      "nimbusel": "docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1:master",
+      "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
+    }
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
     --client.checktimelimit=300s
@@ -101,16 +113,16 @@ jobs:
       hive_repo: ${{ steps.client_config.outputs.hive_repo }}
       hive_tag: ${{ steps.client_config.outputs.hive_tag }}
       client_config: ${{ steps.client_config.outputs.client_config }}
-      client_source: ${{ inputs.client_source || 'git' }}
+      client_source: ${{ inputs.client_source || 'docker' }}
     steps:
       - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         name: "Client config"
         id: client_config
         with:
           client_repos: ${{ inputs.client_repos }}
-          client_images: ${{ inputs.client_images }}
+          client_images: ${{ inputs.client_images || env.DEFAULT_CLIENT_IMAGES }}
           common_client_tag: ${{ inputs.common_client_tag || 'glamsterdam-devnet-8' }}
-          client_source: ${{ inputs.client_source || 'git' }}
+          client_source: ${{ inputs.client_source || 'docker' }}
           hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
           goproxy: ${{ env.GOPROXY }}
 

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -137,7 +137,7 @@ jobs:
         id: client_config_schedule
         with:
           # Prebuilt ethpandaops images track the same devnet branches and are
-          # rebuilt on every push; skips the in-run client build.
+          # rebuilt hourly on the latest commit; skips the in-run client build.
           # Passed explicitly because the helper's own default uses the
           # ghcr.io image for ethrex.
           client_images: |

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -127,7 +127,7 @@ jobs:
       # client_source to determine if we need docker auth
       client_source: >-
         ${{
-          github.event_name == 'schedule' && 'git' ||
+          github.event_name == 'schedule' && 'docker' ||
           inputs.client_source
         }}
     steps:
@@ -136,8 +136,22 @@ jobs:
         name: "Client config: schedule"
         id: client_config_schedule
         with:
+          # Prebuilt ethpandaops images track the same devnet branches and are
+          # rebuilt on every push; skips the in-run client build.
+          # Passed explicitly because the helper's own default uses the
+          # ghcr.io image for ethrex.
+          client_images: |
+            {
+              "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
+              "besu": "docker.ethquokkaops.io/dh/ethpandaops/besu:main",
+              "reth": "docker.ethquokkaops.io/dh/ethpandaops/reth:main",
+              "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
+              "erigon": "docker.ethquokkaops.io/dh/ethpandaops/erigon:main",
+              "nimbusel": "docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1:master",
+              "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
+            }
           common_client_tag: "glamsterdam-devnet-8"
-          client_source: "git"
+          client_source: "docker"
           hive_version: "ethereum/hive@master"
           goproxy: ${{ env.GOPROXY }}
 


### PR DESCRIPTION
Scheduled runs build every client from git inside the run (10–25 min per job before tests start). The ethpandaops image builder rebuilds `<image>:glamsterdam-devnet-8` hourly on the latest commit of the same branches, so scheduled runs now pull those instead — and test exactly the artifact the devnets deploy (at most ~1h behind the branch tip). Images are passed explicitly on the schedule path because the client-config helper's own default uses the ghcr.io image for ethrex. Dispatches keep the `client_source` choice.