### PR TITLE
chore(hive): bump devnet-8 fixtures to glamsterdam-devnet@v8.1.1

### DIFF
--- a/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8-quick.yaml
@@ -121,7 +121,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/8"
     runs-on: >-
       ${{

--- a/.github/workflows/hive-glamsterdam-devnet-8.yaml
+++ b/.github/workflows/hive-glamsterdam-devnet-8.yaml
@@ -160,7 +160,7 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.0/fixtures_glamsterdam-devnet.tar.gz"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-glamsterdam-devnet@v8.1.1/fixtures_glamsterdam-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/glamsterdam/8"
     runs-on: >-
       ${{


### PR DESCRIPTION
Points both devnet-8 workflows at the `tests-glamsterdam-devnet@v8.1.1` fixtures release (ethereum/execution-specs#3311), cut from a reset `devnets/glamsterdam/8` with additional test coverage only, no spec changes. Release run in flight: https://github.com/ethereum/execution-specs/actions/runs/32242759996