### PR TITLE
chore(hive): drop the devnet number from the frames and focil workflow filenames

### DIFF
--- a/.github/workflows/hive-focil-quick.yaml
+++ b/.github/workflows/hive-focil-quick.yaml
@@ -1,14 +1,13 @@
-name: Hive - Frames Devnet 0
+name: Hive - Focil Quick
 on:
   schedule:
-    - cron: "45 15 * * *"
+    - cron: "45 16 * * *"
   workflow_dispatch:
-    # Note: We're limited to 10 inputs
     inputs:
       client:
         type: string
-        default: '"go-ethereum","nethermind","ethrex"'
-        description: Comma-separated list of clients to test .e.g go-ethereum, nethermind, ethrex
+        default: '"besu","nethermind","ethrex","nimbus-el"'
+        description: Comma-separated list of clients to test .e.g besu, nethermind, ethrex, nimbus-el
       simulator:
         type: string
         default: >-
@@ -40,18 +39,20 @@ on:
         type: string
         default: |
           {
-            "geth": "lightclient/go-ethereum@frames",
-            "nethermind": "NethermindEth/nethermind@feature/frames-devnet-0",
-            "ethrex": "lambdaclass/ethrex@frames-devnet-0"
+            "besu": "hyperledger/besu@focil-devnet-0",
+            "nethermind": "NethermindEth/nethermind@feature/eip-7805",
+            "ethrex": "lambdaclass/ethrex@focil-devnet-0",
+            "nimbusel": "status-im/nimbus-eth1@focil-devnet-0"
           }
         description: 'JSON object containing client versions in format {"client": "repo@tag", ...}'
       client_images:
         type: string
         default: |
           {
-            "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
+            "besu": "docker.ethquokkaops.io/dh/ethpandaops/besu:main",
             "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
-            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
+            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main",
+            "nimbusel": "docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1:master"
           }
         description: 'JSON object containing client docker images in format {"client": "registry:tag", ...}'
 
@@ -60,8 +61,8 @@ env:
   GOPROXY: "${{ vars.GOPROXY }}"
   # Hive action environment variables
   S3_BUCKET: hive-results
-  S3_PATH: frames
-  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/frames/
+  S3_PATH: focil-quick
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/focil-quick/
   INSTALL_RCLONE_VERSION: v1.68.2
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
@@ -75,7 +76,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*fork_Bogota.*'
+    --sim.limit='.*7805.*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -83,7 +84,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*fork_Bogota.*'
+    --sim.limit='.*7805.*'
     --sim.limit.exact=false
     --sim.loglevel=3
 
@@ -91,82 +92,53 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      # Hive version
-      hive_repo: >-
-        ${{
-          steps.client_config_schedule.outputs.hive_repo ||
-          steps.client_config_dispatch.outputs.hive_repo
-        }}
-      hive_tag: >-
-        ${{
-          steps.client_config_schedule.outputs.hive_tag ||
-          steps.client_config_dispatch.outputs.hive_tag
-        }}
-      # client_config contains the YAML client config for Hive
-      client_config: >-
-        ${{
-          steps.client_config_schedule.outputs.client_config ||
-          steps.client_config_dispatch.outputs.client_config
-        }}
-      # client_source to determine if we need docker auth
-      client_source: >-
-        ${{
-          github.event_name == 'schedule' && 'git' ||
-          inputs.client_source
-        }}
+      hive_repo: ${{ steps.client_config.outputs.hive_repo }}
+      hive_tag: ${{ steps.client_config.outputs.hive_tag }}
+      client_config: ${{ steps.client_config.outputs.client_config }}
+      client_source: ${{ inputs.client_source || 'git' }}
     steps:
       - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        if: github.event_name == 'schedule'
-        name: "Client config: schedule"
-        id: client_config_schedule
+        name: "Client config"
+        id: client_config
         with:
-          client_repos: |
-            {
-              "geth": "lightclient/go-ethereum@frames",
-              "nethermind": "NethermindEth/nethermind@feature/frames-devnet-0",
-              "ethrex": "lambdaclass/ethrex@frames-devnet-0"
-            }
-          client_source: "git"
-          hive_version: "ethereum/hive@master"
-          goproxy: ${{ env.GOPROXY }}
-
-      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        if: github.event_name == 'workflow_dispatch'
-        name: "Client config: workflow_dispatch"
-        id: client_config_dispatch
-        with:
-          client_repos: ${{ inputs.client_repos }}
+          client_repos: >-
+            ${{ inputs.client_repos ||
+            '{"besu": "hyperledger/besu@focil-devnet-0",
+            "nethermind": "NethermindEth/nethermind@feature/eip-7805",
+            "ethrex": "lambdaclass/ethrex@focil-devnet-0",
+            "nimbusel": "status-im/nimbus-eth1@focil-devnet-0"}' }}
           client_images: ${{ inputs.client_images }}
           common_client_tag: ${{ inputs.common_client_tag }}
-          client_source: ${{ inputs.client_source }}
-          hive_version: ${{ inputs.hive_version }}
+          client_source: ${{ inputs.client_source || 'git' }}
+          hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
           goproxy: ${{ env.GOPROXY }}
 
   test:
-    timeout-minutes: 4320
+    timeout-minutes: 2160
     needs: prepare
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-focil-devnet@v0.2.0/fixtures_focil-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/focil/0"
     runs-on: >-
       ${{
-        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-ccx33-x64' ||
+        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-xl-do-x64' ||
         'ubuntu-latest'
       }}
     concurrency:
       group: >-
-        ${{ github.head_ref || inputs || github.workflow }}-${{ matrix.client }}-${{ matrix.simulator }}
+        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}-quick
     strategy:
       fail-fast: false
       matrix:
         client: >-
           ${{ fromJSON(format('[{0}]', inputs.client || '
-            "go-ethereum",
+            "besu",
             "nethermind",
-            "ethrex"
+            "ethrex",
+            "nimbus-el"
           '))}}
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '

--- a/.github/workflows/hive-focil.yaml
+++ b/.github/workflows/hive-focil.yaml
@@ -1,4 +1,4 @@
-name: Hive - Focil Devnet 0
+name: Hive - Focil
 on:
   schedule:
     - cron: "45 17 * * *"

--- a/.github/workflows/hive-frames-quick.yaml
+++ b/.github/workflows/hive-frames-quick.yaml
@@ -1,4 +1,4 @@
-name: Hive - Frames Devnet 0 Quick
+name: Hive - Frames Quick
 on:
   schedule:
     - cron: "45 14 * * *"

--- a/.github/workflows/hive-frames.yaml
+++ b/.github/workflows/hive-frames.yaml
@@ -1,13 +1,14 @@
-name: Hive - Focil Devnet 0 Quick
+name: Hive - Frames
 on:
   schedule:
-    - cron: "45 16 * * *"
+    - cron: "45 15 * * *"
   workflow_dispatch:
+    # Note: We're limited to 10 inputs
     inputs:
       client:
         type: string
-        default: '"besu","nethermind","ethrex","nimbus-el"'
-        description: Comma-separated list of clients to test .e.g besu, nethermind, ethrex, nimbus-el
+        default: '"go-ethereum","nethermind","ethrex"'
+        description: Comma-separated list of clients to test .e.g go-ethereum, nethermind, ethrex
       simulator:
         type: string
         default: >-
@@ -39,20 +40,18 @@ on:
         type: string
         default: |
           {
-            "besu": "hyperledger/besu@focil-devnet-0",
-            "nethermind": "NethermindEth/nethermind@feature/eip-7805",
-            "ethrex": "lambdaclass/ethrex@focil-devnet-0",
-            "nimbusel": "status-im/nimbus-eth1@focil-devnet-0"
+            "geth": "lightclient/go-ethereum@frames",
+            "nethermind": "NethermindEth/nethermind@feature/frames-devnet-0",
+            "ethrex": "lambdaclass/ethrex@frames-devnet-0"
           }
         description: 'JSON object containing client versions in format {"client": "repo@tag", ...}'
       client_images:
         type: string
         default: |
           {
-            "besu": "docker.ethquokkaops.io/dh/ethpandaops/besu:main",
+            "geth": "docker.ethquokkaops.io/dh/ethpandaops/geth:master",
             "nethermind": "docker.ethquokkaops.io/dh/ethpandaops/nethermind:master",
-            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main",
-            "nimbusel": "docker.ethquokkaops.io/dh/ethpandaops/nimbus-eth1:master"
+            "ethrex": "docker.ethquokkaops.io/dh/ethpandaops/ethrex:main"
           }
         description: 'JSON object containing client docker images in format {"client": "registry:tag", ...}'
 
@@ -61,8 +60,8 @@ env:
   GOPROXY: "${{ vars.GOPROXY }}"
   # Hive action environment variables
   S3_BUCKET: hive-results
-  S3_PATH: focil-quick
-  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/focil-quick/
+  S3_PATH: frames
+  S3_PUBLIC_URL: https://hive.ethpandaops.io/#/test/frames/
   INSTALL_RCLONE_VERSION: v1.68.2
   # Flags used for all simulators
   GLOBAL_EXTRA_FLAGS: >-
@@ -76,7 +75,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*7805.*'
+    --sim.limit='.*fork_Bogota.*'
     --sim.limit.exact=false
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
@@ -84,7 +83,7 @@ env:
     --sim.parallelism=6
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
-    --sim.limit='.*7805.*'
+    --sim.limit='.*fork_Bogota.*'
     --sim.limit.exact=false
     --sim.loglevel=3
 
@@ -92,53 +91,82 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      hive_repo: ${{ steps.client_config.outputs.hive_repo }}
-      hive_tag: ${{ steps.client_config.outputs.hive_tag }}
-      client_config: ${{ steps.client_config.outputs.client_config }}
-      client_source: ${{ inputs.client_source || 'git' }}
+      # Hive version
+      hive_repo: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_repo ||
+          steps.client_config_dispatch.outputs.hive_repo
+        }}
+      hive_tag: >-
+        ${{
+          steps.client_config_schedule.outputs.hive_tag ||
+          steps.client_config_dispatch.outputs.hive_tag
+        }}
+      # client_config contains the YAML client config for Hive
+      client_config: >-
+        ${{
+          steps.client_config_schedule.outputs.client_config ||
+          steps.client_config_dispatch.outputs.client_config
+        }}
+      # client_source to determine if we need docker auth
+      client_source: >-
+        ${{
+          github.event_name == 'schedule' && 'git' ||
+          inputs.client_source
+        }}
     steps:
       - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
-        name: "Client config"
-        id: client_config
+        if: github.event_name == 'schedule'
+        name: "Client config: schedule"
+        id: client_config_schedule
         with:
-          client_repos: >-
-            ${{ inputs.client_repos ||
-            '{"besu": "hyperledger/besu@focil-devnet-0",
-            "nethermind": "NethermindEth/nethermind@feature/eip-7805",
-            "ethrex": "lambdaclass/ethrex@focil-devnet-0",
-            "nimbusel": "status-im/nimbus-eth1@focil-devnet-0"}' }}
+          client_repos: |
+            {
+              "geth": "lightclient/go-ethereum@frames",
+              "nethermind": "NethermindEth/nethermind@feature/frames-devnet-0",
+              "ethrex": "lambdaclass/ethrex@frames-devnet-0"
+            }
+          client_source: "git"
+          hive_version: "ethereum/hive@master"
+          goproxy: ${{ env.GOPROXY }}
+
+      - uses: ethpandaops/hive-github-action/helpers/client-config@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
+        if: github.event_name == 'workflow_dispatch'
+        name: "Client config: workflow_dispatch"
+        id: client_config_dispatch
+        with:
+          client_repos: ${{ inputs.client_repos }}
           client_images: ${{ inputs.client_images }}
           common_client_tag: ${{ inputs.common_client_tag }}
-          client_source: ${{ inputs.client_source || 'git' }}
-          hive_version: ${{ inputs.hive_version || 'ethereum/hive@master' }}
+          client_source: ${{ inputs.client_source }}
+          hive_version: ${{ inputs.hive_version }}
           goproxy: ${{ env.GOPROXY }}
 
   test:
-    timeout-minutes: 2160
+    timeout-minutes: 4320
     needs: prepare
     env:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-focil-devnet@v0.2.0/fixtures_focil-devnet.tar.gz"
-      EELS_BUILD_ARG_BRANCH: "devnets/focil/0"
+      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
+      EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
     runs-on: >-
       ${{
-        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-xl-do-x64' ||
+        contains(matrix.simulator, 'ethereum/eels/') && 'self-hosted-ghr-size-ccx33-x64' ||
         'ubuntu-latest'
       }}
     concurrency:
       group: >-
-        ${{ github.head_ref || inputs }}-${{ matrix.client }}-${{ matrix.simulator }}-quick
+        ${{ github.head_ref || inputs || github.workflow }}-${{ matrix.client }}-${{ matrix.simulator }}
     strategy:
       fail-fast: false
       matrix:
         client: >-
           ${{ fromJSON(format('[{0}]', inputs.client || '
-            "besu",
+            "go-ethereum",
             "nethermind",
-            "ethrex",
-            "nimbus-el"
+            "ethrex"
           '))}}
         simulator: >-
           ${{ fromJSON(format('[{0}]', inputs.simulator || '


### PR DESCRIPTION
Renames `hive-{frames,focil}-devnet-0{,-quick}.yaml` → `hive-{frames,focil}{,-quick}.yaml` (display names likewise).

hive-ui link update: ethpandaops/hive-ui#84.