### PR TITLE
feat(hive): resolve the greatest published fixtures release in the frames and focil workflows

### DIFF
--- a/.github/scripts/resolve_fixtures_release.py
+++ b/.github/scripts/resolve_fixtures_release.py
@@ -1,0 +1,79 @@
+"""
+Resolve the fixtures release a hive workflow should consume.
+
+Picks the greatest published `<prefix>@vX.Y.Z` release of
+ethereum/execution-specs, or validates a pinned tag from the
+`FIXTURES_TAG` environment variable. Draft releases are invisible to
+the API, so workflows stay on the previous release until a new one is
+published. Writes `EELS_BUILD_ARG_FIXTURES=<download url>` to
+`GITHUB_ENV` and logs the chosen tag to `GITHUB_STEP_SUMMARY` when
+those files are available, and always prints the tag.
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+RELEASES_URL = (
+    "https://api.github.com/repos/ethereum/execution-specs/"
+    "releases?per_page=100"
+)
+
+
+def version_key(tag: str) -> tuple:
+    """Sort key for a `<prefix>@vX.Y.Z` tag."""
+    version = tag.split("@v", 1)[1]
+    return tuple(int(part) for part in version.split("."))
+
+
+def resolve(prefix: str) -> str:
+    """Return the greatest published release tag for the prefix."""
+    request = urllib.request.Request(RELEASES_URL)
+    token = os.environ.get("GH_TOKEN")
+    if token:
+        request.add_header("Authorization", f"Bearer {token}")
+    with urllib.request.urlopen(request, timeout=30) as response:
+        releases = json.load(response)
+    tags = [
+        release["tag_name"]
+        for release in releases
+        if release["tag_name"].startswith(f"{prefix}@v")
+        and not release["draft"]
+    ]
+    if not tags:
+        sys.exit(f"no published {prefix} release found")
+    return max(tags, key=version_key)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prefix", required=True, help="release tag family")
+    parser.add_argument("--asset", required=True, help="fixtures asset name")
+    args = parser.parse_args()
+
+    tag = os.environ.get("FIXTURES_TAG", "").strip()
+    if tag:
+        if not tag.startswith(f"{args.prefix}@v"):
+            sys.exit(f"pinned tag {tag} is not a {args.prefix} release")
+    else:
+        tag = resolve(args.prefix)
+
+    url = (
+        "https://github.com/ethereum/execution-specs/releases/download/"
+        f"{tag}/{args.asset}"
+    )
+    print(tag)
+    github_env = os.environ.get("GITHUB_ENV")
+    if github_env:
+        with open(github_env, "a") as env_file:
+            env_file.write(f"EELS_BUILD_ARG_FIXTURES={url}\n")
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with open(summary, "a") as summary_file:
+            summary_file.write(f"Using fixtures release: `{tag}`\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/hive-focil-quick.yaml
+++ b/.github/workflows/hive-focil-quick.yaml
@@ -4,6 +4,12 @@ on:
     - cron: "45 16 * * *"
   workflow_dispatch:
     inputs:
+      fixtures_tag:
+        type: string
+        default: ""
+        description: >-
+          Pin a fixtures release tag e.g. tests-focil-devnet@v0.1.0.
+          Empty resolves the greatest published tests-focil-devnet tag.
       client:
         type: string
         default: '"besu","nethermind","ethrex","nimbus-el"'
@@ -120,7 +126,6 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-focil-devnet@v0.2.0/fixtures_focil-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/focil/0"
     runs-on: >-
       ${{
@@ -147,6 +152,14 @@ jobs:
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve fixtures release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIXTURES_TAG: ${{ inputs.fixtures_tag }}
+        run: |
+          python3 .github/scripts/resolve_fixtures_release.py \
+            --prefix tests-focil-devnet \
+            --asset fixtures_focil-devnet.tar.gz
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: runner.environment != 'github-hosted'
       - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d

--- a/.github/workflows/hive-focil.yaml
+++ b/.github/workflows/hive-focil.yaml
@@ -5,6 +5,12 @@ on:
   workflow_dispatch:
     # Note: We're limited to 10 inputs
     inputs:
+      fixtures_tag:
+        type: string
+        default: ""
+        description: >-
+          Pin a fixtures release tag e.g. tests-focil-devnet@v0.1.0.
+          Empty resolves the greatest published tests-focil-devnet tag.
       client:
         type: string
         default: '"besu","nethermind","ethrex","nimbus-el"'
@@ -152,7 +158,6 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-focil-devnet@v0.2.0/fixtures_focil-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/focil/0"
     runs-on: >-
       ${{
@@ -179,6 +184,14 @@ jobs:
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve fixtures release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIXTURES_TAG: ${{ inputs.fixtures_tag }}
+        run: |
+          python3 .github/scripts/resolve_fixtures_release.py \
+            --prefix tests-focil-devnet \
+            --asset fixtures_focil-devnet.tar.gz
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: runner.environment != 'github-hosted'
       - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d

--- a/.github/workflows/hive-frames-quick.yaml
+++ b/.github/workflows/hive-frames-quick.yaml
@@ -4,6 +4,12 @@ on:
     - cron: "45 14 * * *"
   workflow_dispatch:
     inputs:
+      fixtures_tag:
+        type: string
+        default: ""
+        description: >-
+          Pin a fixtures release tag e.g. tests-frames-devnet@v0.1.0.
+          Empty resolves the greatest published tests-frames-devnet tag.
       client:
         type: string
         default: '"go-ethereum","nethermind","ethrex"'
@@ -117,7 +123,6 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
     runs-on: >-
       ${{
@@ -143,6 +148,14 @@ jobs:
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve fixtures release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIXTURES_TAG: ${{ inputs.fixtures_tag }}
+        run: |
+          python3 .github/scripts/resolve_fixtures_release.py \
+            --prefix tests-frames-devnet \
+            --asset fixtures_frames-devnet.tar.gz
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: runner.environment != 'github-hosted'
       - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d

--- a/.github/workflows/hive-frames.yaml
+++ b/.github/workflows/hive-frames.yaml
@@ -5,6 +5,12 @@ on:
   workflow_dispatch:
     # Note: We're limited to 10 inputs
     inputs:
+      fixtures_tag:
+        type: string
+        default: ""
+        description: >-
+          Pin a fixtures release tag e.g. tests-frames-devnet@v0.1.0.
+          Empty resolves the greatest published tests-frames-devnet tag.
       client:
         type: string
         default: '"go-ethereum","nethermind","ethrex"'
@@ -149,7 +155,6 @@ jobs:
       # BAL-specific environment variables
       HIVE_PARALLEL_TX_PROCESSING_DISABLED: "true"
       HIVE_AMSTERDAM_TIMESTAMP: "1777456800"
-      EELS_BUILD_ARG_FIXTURES: "https://github.com/ethereum/execution-specs/releases/download/tests-frames-devnet@v0.0.0/fixtures_frames-devnet.tar.gz"
       EELS_BUILD_ARG_BRANCH: "devnets/frames/0"
     runs-on: >-
       ${{
@@ -175,6 +180,14 @@ jobs:
           '))}}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Resolve fixtures release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          FIXTURES_TAG: ${{ inputs.fixtures_tag }}
+        run: |
+          python3 .github/scripts/resolve_fixtures_release.py \
+            --prefix tests-frames-devnet \
+            --asset fixtures_frames-devnet.tar.gz
       - uses: ethpandaops/hive-github-action/helpers/self-hosted-runner-dependencies@09050fc75bae8a10b1876a0826ca4114ea9ed6e8 # v0.6.3
         if: runner.environment != 'github-hosted'
       - uses: ethpandaops/actions/docker-login@a91b7a8dd6a264f5e845ac2aa52d2d6f24e6d01d


### PR DESCRIPTION
Replaces the hardcoded EELS_BUILD_ARG_FIXTURES tag in the frames and focil workflow pairs with a resolve step that picks the greatest published tests-<family>-devnet release at run time (drafts stay invisible, so scheduled runs keep the old fixtures until a release is published and flip automatically). A new fixtures_tag dispatch input pins a specific tag when needed. Ends the bump-PR-per-release flow, starting with tests-frames-devnet@v0.1.0 (tracker ethereum/execution-specs#3415).