### PR TITLE
feat(hive): raise sim.parallelism from 4 to 8 for consume-engine/rlp in the generic workflow

### DIFF
--- a/.github/workflows/generic.yaml
+++ b/.github/workflows/generic.yaml
@@ -107,17 +107,25 @@ env:
     --docker.auth
     --docker.buildoutput
   # Flags used for the ethereum/eels/consume-engine simulator
+  # (appended after GLOBAL_EXTRA_FLAGS; hive takes the last occurrence of a
+  # repeated flag, so --sim.parallelism here overrides the global value)
   EELS_ENGINE_FLAGS: >-
+    --sim.parallelism=8
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-enginex simulator
+  # (keeps the global --sim.parallelism: enginex's whole-fork parallelism is
+  # capped at ~2-3x by the pre-alloc group-size distribution, so raising it
+  # buys nothing until group reduction lands)
   EELS_ENGINEX_FLAGS: >-
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
     --sim.loglevel=3
   # Flags used for the ethereum/eels/consume-rlp simulator
+  # (--sim.parallelism overrides the global value, as above)
   EELS_RLP_FLAGS: >-
+    --sim.parallelism=8
     --sim.buildarg fixtures=${EELS_BUILD_ARG_FIXTURES}
     --sim.buildarg branch=${EELS_BUILD_ARG_BRANCH}
     --sim.loglevel=3


### PR DESCRIPTION
Raises `--sim.parallelism` from 4 to 8 for `ethereum/eels/consume-engine` and `ethereum/eels/consume-rlp` in the generic workflow.

ethereum/hive#1600 (merged 2026-08-20) releases the libhive test-case mutex during container teardown, which serialized every worker's teardown against every client start and capped effective parallelism at ~4. The generic workflow tracks `ethereum/hive@master`, so runs already carry the fix; benchmarking with the fix recommends 8 for consume-engine and 8–16 for consume-rlp.

These simulators run on `self-hosted-ghr-size-ccx33-x64` runners (Hetzner CCX33: 8 dedicated vCPUs = SMT threads on 4 physical cores, 32 GB RAM), so 8 is one worker per logical core and likely the practical cap for this machine size — going higher only makes sense together with a larger runner class.

`consume-enginex` keeps the global value of 4: its whole-fork parallelism is capped at ~2–3× by the pre-alloc group-size distribution until group reduction lands.
